### PR TITLE
Fix issue with empty bucket prefix

### DIFF
--- a/aws_log_forwarder/locals.tf
+++ b/aws_log_forwarder/locals.tf
@@ -4,8 +4,7 @@ locals {
   role_name                  = var.role_name == null ? "${var.name}-role" : var.role_name
   role_arn                   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.role_name}"
   logging_bucket_arn         = "arn:aws:s3:::${var.logging_bucket.name}"
-  prefix_with_trailing_slash = endswith(var.logging_bucket.prefix, "/") ? var.logging_bucket.prefix : format("%s/", var.logging_bucket.prefix)
-  logging_bucket_prefix_arn  = "${local.logging_bucket_arn}/${local.prefix_with_trailing_slash}"
+  logging_bucket_prefix_arn  = "${local.logging_bucket_arn}/${var.logging_bucket.prefix}"
   filename                   = "lambda_${var.name}.zip"
   artefact_url_suffix        = var.artifact_version == "latest" ? "latest/download/brontobytes-aws-ingestion-python.zip" : "download/${var.artifact_version}/brontobytes-aws-ingestion-python.zip"
   artefact_url               = "https://github.com/logchatio/brontobytes-aws-ingestion-python/releases/${local.artefact_url_suffix}"

--- a/aws_log_forwarder/main.tf
+++ b/aws_log_forwarder/main.tf
@@ -64,6 +64,6 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   lambda_function {
     lambda_function_arn = aws_lambda_function.this.arn
     events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = local.prefix_with_trailing_slash
+    filter_prefix       = var.logging_bucket.prefix
   }
 }

--- a/aws_log_forwarder/variables.tf
+++ b/aws_log_forwarder/variables.tf
@@ -6,7 +6,7 @@ variable "logging_bucket" {
   description = "Config representing the bucket containing logs. The bucket may contain logs from different sources under the provided prefix"
   type        = object({
     name: string
-    prefix: string
+    prefix: optional(string, "")
   })
 }
 


### PR DESCRIPTION
This change overcomes the issue where the IAM policy to access data on S3 does not capture S3 prefixes correctly, leading to permission issues.

This change was tested with
- an empty prefix
- a null prefix (falls back to empty)
- a prefix not ending with /
- and a prefix ending with /
