### PR TITLE
Decouple enabling EventBridge on buckets from creating EventBridge rules

### DIFF
--- a/aws_log_forwarder/iam.tf
+++ b/aws_log_forwarder/iam.tf
@@ -37,9 +37,11 @@ resource "aws_iam_policy_attachment" "s3_access" {
   name       = "S3AccessLoggingBucketRO"
   policy_arn = aws_iam_policy.s3_access.arn
   roles      = [local.role_name]
+  depends_on = [aws_iam_role.this]
 }
 
 resource "aws_iam_role_policy_attachment" "basic" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   role       = local.role_name
+  depends_on = [aws_iam_role.this]
 }

--- a/aws_log_forwarder/notifications/eventbridge.tf
+++ b/aws_log_forwarder/notifications/eventbridge.tf
@@ -1,0 +1,31 @@
+#
+# EventBridge
+#
+resource "aws_lambda_permission" "allow_event_bridge" {
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_function_arn
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.bucket_notification.arn
+}
+
+resource "aws_cloudwatch_event_rule" "bucket_notification" {
+  name        = "s3-notification-${var.name}"
+  description = "Rules to notify on log data delivered to S3"
+  event_pattern = jsonencode({
+    detail-type = ["Object Created"]
+    source = ["aws.s3"]
+    detail = {
+      bucket = {
+        name = [var.logging_bucket.name]
+      }
+    }
+  })
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "lambda" {
+  rule      = aws_cloudwatch_event_rule.bucket_notification.name
+  target_id = "${ var.name }-lambda"
+  arn       = var.lambda_function_arn
+}

--- a/aws_log_forwarder/notifications/variables.tf
+++ b/aws_log_forwarder/notifications/variables.tf
@@ -1,0 +1,26 @@
+variable "name" {
+  description = "A name of the component"
+}
+
+variable "logging_bucket" {
+  description = "Config representing the bucket containing logs. The bucket may contain logs from different sources under the provided prefix"
+  type        = object({
+    name: string
+    prefix: optional(string, "")
+  })
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+}
+
+variable "with_s3_notification" {
+  description = "Whether to set S3 notifications (See README file for details)"
+  type        = bool
+  default     = true
+}
+
+variable "lambda_function_arn" {
+  description = "The ARN of the forwarding lambda function"
+}

--- a/aws_log_forwarder/variables.tf
+++ b/aws_log_forwarder/variables.tf
@@ -76,3 +76,15 @@ variable "with_s3_notification" {
   type        = bool
   default     = true
 }
+
+variable "with_eventbridge_rule" {
+  description = "Whether to create EventBridge rule"
+  type        = bool
+  default     = false
+}
+
+variable "enable_eventbridge_notification" {
+  description = "Whether to get notifications via EventBridge"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This change makes it possible to 
- enable EventBridge events on the logging bucket
- create EventBridge rules to trigger the forwarding lambda
- do either of the above independently of each other to accommodate for the case where S3 notifications/EventBridge configuration would be controlled by another solution.

Overall this enables having co-existing log forwarder/shippers.

Tested with:
- S3 notifications
- EventBridge + S3 notifications on a single bucket (co-existing solutions)