### PR TITLE
Update references to Github organisation name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here is a sample usage of this Terraform module, where lambda logs, S3 access lo
 are forwarded to Bronto. 
 ```hcl
 module "bronto_aws_log_forwarding" {
-  source = "git::https://github.com/logchatio/brontobytes-aws-ingestion-terraform.git//aws_log_forwarder"
+  source = "git::https://github.com/brontoio/brontobytes-aws-ingestion-terraform.git//aws_log_forwarder"
   with_s3_notification = false
   logging_bucket   = {name="<LOGGING_BUCKET_NAME>", prefix="<LOGGING_BUCKET_PREFIX>"}
   name             = "bronto_aws_log_forwarder"
@@ -86,7 +86,7 @@ Bronto related configuration:
 - `bronto_api_key`: the Bronto API key
 - `uncompressed_max_batch_size`: the max size of the batches of data to be forwarded to Bronto
 - `destination_config`: list of configurations indicating the type of data to be forwarded as well as the destination 
-in Bronto where to send the data to. More details can be found in the [forwarding Lambda function repository](https://github.com/logchatio/brontobytes-aws-ingestion-python). 
+in Bronto where to send the data to. More details can be found in the [forwarding Lambda function repository](https://github.com/brontoio/brontobytes-aws-ingestion-python). 
 
 
 **Note:** The `with_s3_notification` variable makes it possible to control whether S3 notifications get set up as part of 

--- a/aws_log_forwarder/locals.tf
+++ b/aws_log_forwarder/locals.tf
@@ -7,6 +7,6 @@ locals {
   logging_bucket_prefix_arn  = "${local.logging_bucket_arn}/${var.logging_bucket.prefix}"
   filename                   = "lambda_${var.name}.zip"
   artefact_url_suffix        = var.artifact_version == "latest" ? "latest/download/brontobytes-aws-ingestion-python.zip" : "download/${var.artifact_version}/brontobytes-aws-ingestion-python.zip"
-  artefact_url               = "https://github.com/logchatio/brontobytes-aws-ingestion-python/releases/${local.artefact_url_suffix}"
+  artefact_url               = "https://github.com/brontoio/brontobytes-aws-ingestion-python/releases/${local.artefact_url_suffix}"
   artefact_url_b64sha256     = "${local.artefact_url}.b64sha256"
 }


### PR DESCRIPTION
Github provides redirections to the new repo URLs and Terraform honours those redirections, on organisation name change. So Github organisation renaming is not an issue to use the module.

However, in order to avoid potential long term issues and also to reflect better the Github organisation that this repository belongs to, we update references of the old org name to the new one. 