### PR TITLE
Add support for cloudwatch account level subscription

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,28 @@
+name: Tag
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  deployment:
+    environment: production
+
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+      deployments: write
+
+    env:
+      VERSION: "1.0.${{ github.run_number }}-${{ github.run_attempt }}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Tag Version
+        if: success()
+        run: git tag ${{ env.VERSION }} && git push --tags
+        shell: bash

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,14 @@
+## Migrations
+
+### From 0.x to 1.x
+
+Version 1.0.0 introduces the lambda forwarder Cloudwatch log group definition. For forwarder that are already setup 
+and running, this log group already exists. This will lead to an error when applying this module with Terraform. To 
+overcome, this issue:
+
+- either delete the Bronto Forwarder log group in the corresponding AWS account,
+- or import the log group resource via a command similar to:
+
+```
+terraform import 'module.bronto_forwarder.aws_cloudwatch_log_group.this' '/aws/lambda/bronto_forwarder'
+```

--- a/README.md
+++ b/README.md
@@ -47,20 +47,25 @@ module "bronto_aws_log_forwarding" {
   uncompressed_max_batch_size = 5000000  # 5Mb
   destination_config   = {
     "/aws/lambda/my-function-name" = {
-      logname  = "<BRONTO DESTINATION LOG_NAME>"
-      logset   = "<BRONTO DESTINATION COLLECTION>"
-      log_type = "cloudwatch_log"
+      dataset    = "<BRONTO DESTINATION LOG_NAME>"
+      collection = "<BRONTO DESTINATION COLLECTION>"
+      log_type   = "cloudwatch_log"
     }
     "<BUCKET_WHOSE_ACCESS_LOGS_ARE_COLLECTED>" = {
-      logname  = "<BRONTO DESTINATION LOG_NAME>"
-      logset   = "<BRONTO DESTINATION COLLECTION>"
-      log_type = "s3_access_log"
+      dataset    = "<BRONTO DESTINATION LOG_NAME>"
+      collection = "<BRONTO DESTINATION COLLECTION>"
+      log_type   = "s3_access_log"
     }
     "<CLOUDFRONT_DISTRIBUBTION_ID>" = {
-      logname  = "<BRONTO DESTINATION LOG_NAME>"
-      logset   = "<BRONTO DESTINATION COLLECTION>"
-      log_type = "cf_standard_access_log"
+      dataset    = "<BRONTO DESTINATION LOG_NAME>"
+      collection = "<BRONTO DESTINATION COLLECTION>"
+      log_type   = "cf_standard_access_log"
     }
+  },
+  cloudwatch_default_collection = "Cloudwatch"
+  account_level_cloudwatch_subscription = {
+    enable = true
+    excluded_log_groups = ["log_group1", "log_group2"]
   }
 }
 ```
@@ -86,7 +91,12 @@ Bronto related configuration:
 - `bronto_api_key`: the Bronto API key
 - `uncompressed_max_batch_size`: the max size of the batches of data to be forwarded to Bronto
 - `destination_config`: list of configurations indicating the type of data to be forwarded as well as the destination 
-in Bronto where to send the data to. More details can be found in the [forwarding Lambda function repository](https://github.com/brontoio/brontobytes-aws-ingestion-python). 
+in Bronto where to send the data to. For Cloudwatch log groups, this module provides the ability to 
+create an account level subscription filter via the `account_level_cloudwatch_subscription` property. When enabled, 
+data of all log groups will be received and forwarded by the Bronto Lambda forwarder. The destination collection can be 
+set with the `cloudwatch_default_collection` property, while the destination dataset is represented by the log group 
+name. More details can be found in the [forwarding Lambda function repository](https://github.com/brontoio/brontobytes-aws-ingestion-python). 
+
 
 
 **Note:** The `with_s3_notification` variable makes it possible to control whether S3 notifications get set up as part of 

--- a/aws_log_forwarder/cloudwatch_subscriptions.tf
+++ b/aws_log_forwarder/cloudwatch_subscriptions.tf
@@ -1,0 +1,28 @@
+resource "aws_cloudwatch_log_subscription_filter" "this" {
+  for_each        = { for key in local.log_groups_with_individual_subscription: key => var.destination_config[key] }
+  name            = var.name
+  log_group_name  = each.key
+  filter_pattern  = ""
+  destination_arn = aws_lambda_function.this.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "${replace(title(replace(var.name, "_", " ")), " ", "")}AllowExecutionFromCloudwatch"
+  action        = "lambda:InvokeFunction"
+  function_name = var.name
+  principal     = "logs.${data.aws_region.current.name}.amazonaws.com"
+}
+
+resource "aws_cloudwatch_log_account_policy" "subscription_filter" {
+  count       = var.account_level_cloudwatch_subscription.enable ? 1 : 0
+  policy_name = "subscription-filter"
+  policy_type = "SUBSCRIPTION_FILTER_POLICY"
+  policy_document = jsonencode(
+    {
+      DestinationArn = aws_lambda_function.this.arn
+      FilterPattern  = ""
+    }
+  )
+  selection_criteria = "LogGroupName NOT IN [${join(",", formatlist("\"%s\"", local.excluded_log_groups))}]"
+  depends_on = [aws_lambda_permission.allow_cloudwatch, aws_lambda_function.this]
+}

--- a/aws_log_forwarder/iam.tf
+++ b/aws_log_forwarder/iam.tf
@@ -23,7 +23,8 @@ data "aws_iam_policy_document" "s3_access" {
     effect = "Allow"
     resources = [
       "${local.logging_bucket_prefix_arn}*",
-      "${var.artifact_bucket.arn}/${var.name}/*"
+      "${var.artifact_bucket.arn}/${var.name}/*",
+      "${var.artifact_bucket.arn}/${local.otel_config_s3_key}"
     ]
     actions   = ["s3:Get*", "s3:List*"]
   }

--- a/aws_log_forwarder/locals.tf
+++ b/aws_log_forwarder/locals.tf
@@ -1,12 +1,28 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {}
+
 locals {
-  role_name                  = var.role_name == null ? "${var.name}-role" : var.role_name
-  role_arn                   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.role_name}"
-  logging_bucket_arn         = "arn:aws:s3:::${var.logging_bucket.name}"
-  logging_bucket_prefix_arn  = "${local.logging_bucket_arn}/${var.logging_bucket.prefix}"
-  filename                   = "lambda_${var.name}.zip"
-  artefact_url_suffix        = var.artifact_version == "latest" ? "latest/download/brontobytes-aws-ingestion-python.zip" : "download/${var.artifact_version}/brontobytes-aws-ingestion-python.zip"
-  artefact_url               = "https://github.com/brontoio/brontobytes-aws-ingestion-python/releases/${local.artefact_url_suffix}"
-  artefact_url_b64sha256     = "${local.artefact_url}.b64sha256"
+  role_name                               = var.role_name == null ? "${var.name}-role" : var.role_name
+  role_arn                                = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.role_name}"
+  logging_bucket_arn                      = "arn:aws:s3:::${var.logging_bucket.name}"
+  logging_bucket_prefix_arn               = "${local.logging_bucket_arn}/${var.logging_bucket.prefix}"
+  filename                                = "lambda_${var.name}.zip"
+  artefact_url_suffix                     = var.artifact_version == "latest" ? "latest/download/brontobytes-aws-ingestion-python.zip" : "download/${var.artifact_version}/brontobytes-aws-ingestion-python.zip"
+  artefact_url                            = "https://github.com/brontoio/brontobytes-aws-ingestion-python/releases/${local.artefact_url_suffix}"
+  artefact_url_b64sha256                  = "${local.artefact_url}.b64sha256"
+  log_groups_with_individual_subscription = [
+    for key in keys(var.destination_config) : key
+    if lookup(var.destination_config[key], "log_type", "") == "cloudwatch_log" && var.destination_config[key].set_individual_subscription
+  ]
+  excluded_log_groups = concat(var.account_level_cloudwatch_subscription.excluded_log_groups, [
+    aws_cloudwatch_log_group.this.name
+  ], local.log_groups_with_individual_subscription)
+  fct_destination_properties              = {
+    for key, value in var.destination_config : key =>
+    {for prop in keys(value) : prop => value[prop] if prop != "set_individual_subscription"}
+  }
+  collector_extension_arn = var.forwarder_logs.collector_extension_arn != null ? var.forwarder_logs.collector_extension_arn : "arn:aws:lambda:${data.aws_region.current.name}:184161586896:layer:opentelemetry-collector-arm64-0_12_0:1"
+  otel_config_s3_key = "otel_config/collector.yaml"
+  otel_config_s3_uri = "s3://${var.artifact_bucket.name}.s3.${data.aws_region.current.name}.amazonaws.com/${local.otel_config_s3_key}"
 }

--- a/aws_log_forwarder/main.tf
+++ b/aws_log_forwarder/main.tf
@@ -12,6 +12,20 @@ resource "aws_s3_object" "log_forwarder" {
   content_base64 = data.http.package.response_body_base64
 }
 
+resource "aws_s3_object" "otel_collector_config" {
+  count          = var.forwarder_logs.forward_enable ? 1 : 0
+  bucket         = var.artifact_bucket.name
+  key            = local.otel_config_s3_key
+  content_base64 = base64encode(templatefile("${path.module}/resources/collector.yaml.tmpl",
+    {service_name = var.forwarder_logs.service_name, cloudwatch_default_collection = var.cloudwatch_default_collection}))
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/aws/lambda/${var.name}"
+  retention_in_days = var.function_log_retention_in_days
+  tags              = var.tags
+}
+
 resource "aws_lambda_function" "this" {
   s3_bucket        = aws_s3_object.log_forwarder.bucket
   s3_key           = aws_s3_object.log_forwarder.key
@@ -38,13 +52,16 @@ resource "aws_lambda_function" "this" {
 
   environment {
     variables = {
-      destination_config = base64encode(jsonencode(var.destination_config))
-      bronto_api_key     = var.bronto_api_key
-      bronto_endpoint    = var.bronto_ingestion_endpoint
-      max_batch_size     = var.uncompressed_max_batch_size
+      destination_config        = base64encode(jsonencode(local.fct_destination_properties))
+      bronto_api_key            = var.bronto_api_key
+      bronto_endpoint           = var.bronto_ingestion_endpoint
+      bronto_otel_logs_endpoint = var.bronto_otel_logs_endpoint
+      max_batch_size            = var.uncompressed_max_batch_size
+      cloudwatch_default_collection      = var.cloudwatch_default_collection
+      OPENTELEMETRY_COLLECTOR_CONFIG_URI = var.forwarder_logs.forward_enable ? local.otel_config_s3_uri : null
     }
   }
-
+  layers = var.forwarder_logs.forward_enable ? [local.collector_extension_arn] : []
   tags = { service = "aws_logging" }
 
 }

--- a/aws_log_forwarder/resources/collector.yaml.tmpl
+++ b/aws_log_forwarder/resources/collector.yaml.tmpl
@@ -1,0 +1,23 @@
+receivers:
+  telemetryapi:
+    types: ["platform", "function"]
+processors:
+  batch:
+exporters:
+  debug:
+    verbosity: detailed
+  otlphttp/bronto:
+    logs_endpoint: $${env:bronto_otel_logs_endpoint}
+    compression: none
+    headers:
+      x-bronto-api-key: $${env:bronto_api_key}
+      x-bronto-logset: ${cloudwatch_default_collection}
+      x-bronto-service-name: ${service_name}
+      User-Agent: OpenTelemetry Collector Contrib Lambda
+      Content-Type: application/x-protobuf
+service:
+  pipelines:
+    logs/bronto:
+      receivers: [telemetryapi]
+      processors: [batch]
+      exporters: [otlphttp/bronto]

--- a/aws_log_forwarder/variables.tf
+++ b/aws_log_forwarder/variables.tf
@@ -11,11 +11,12 @@ variable "logging_bucket" {
 }
 
 variable "destination_config" {
-  description = "Config mapping prefixes/logs to BrontoBytes logname and logset"
+  description = "Config mapping prefixes/logs to BrontoBytes logname and logset. Even though not recommended, set_individual_subscription allows to create an individual subscription filter for cloudwatch log groups"
   type        = map(object({
     logname: string
     logset: string
     log_type: string
+    set_individual_subscription: optional(bool, false)
   }))
 }
 
@@ -44,8 +45,13 @@ variable "bronto_api_key" {
 }
 
 variable "bronto_ingestion_endpoint" {
-  description = "Brontobytes ingestion endpoint"
+  description = "Bronto ingestion endpoint"
   default     = "https://ingestion.brontobytes.io/"
+}
+
+variable "bronto_otel_logs_endpoint" {
+  description = "Bronto OTEL ingestion endpoint, e.g. https://ingestion.eu.bronto.io/v1/logs"
+  default     = null
 }
 
 variable "uncompressed_max_batch_size" {
@@ -87,4 +93,34 @@ variable "enable_eventbridge_notification" {
   description = "Whether to get notifications via EventBridge"
   type        = bool
   default     = false
+}
+
+variable "account_level_cloudwatch_subscription" {
+  description = "Account level subscription. The log group matching "
+  type        = object({
+    enable: optional(bool, true)
+    excluded_log_groups: optional(list(string), [])
+  })
+}
+
+variable "cloudwatch_default_collection" {
+  description = "The default Bronto Collection where to forward Cloudwatch logs to"
+  default     = null
+}
+
+variable "function_log_retention_in_days" {
+  description = "The Cloudwatch retention of the lambda forwarder logs"
+  default     = 365
+}
+
+variable "forwarder_logs" {
+  description = "Config to forward the forwarder fct logs"
+  type        = object({
+    forward_enable: optional(bool, true)
+    service_name: optional(string, "bronto-aws-forwarder")
+    collector_extension_arn: optional(string)
+  })
+  default = {
+    forward_enable = false
+  }
 }


### PR DESCRIPTION
This change:

- introduces the ability to setup a Cloudwatch account level subscription, meaning that it is no longer to update the forwarder configuration with every log group data to be forwarded.
- introduce the ability to forward the forwarder logs to Bronto