### PR TITLE
Add support for dedicated s3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ For the forwarding Lambda function:
 
 The lambda code artifact is automatically downloaded from Bronto's Github repository and uploaded to S3. The following 
 attributes specify the bucket where to upload the artifact to so that is can be used to define the forwarding lambda. 
-- `artifact_bucket`: an object representing the S3 bucket where the lambda code artifact should be stored (`name`, `id` and `arn` fields are required).
+- `artifact_bucket`: an object representing the S3 bucket where the lambda code artifact should be stored. If the 
+`create` attribute is set to `true`, then a bucket is created with either the specified `name` or with a default name 
+(currently `bronto-aws-forwarder-<ACCOUNT_ID>-<REGION>`).
 - `artifact_version`: the version of the lambda artifact to be used, e.g. `latest`
 
 For data delivered to S3:

--- a/aws_log_forwarder/iam.tf
+++ b/aws_log_forwarder/iam.tf
@@ -23,8 +23,8 @@ data "aws_iam_policy_document" "s3_access" {
     effect = "Allow"
     resources = [
       "${local.logging_bucket_prefix_arn}*",
-      "${var.artifact_bucket.arn}/${var.name}/*",
-      "${var.artifact_bucket.arn}/${local.otel_config_s3_key}"
+      "${local.artefact_bucket["arn"]}/${var.name}/*",
+      "${local.artefact_bucket["arn"]}/${local.otel_config_s3_key}"
     ]
     actions   = ["s3:Get*", "s3:List*"]
   }

--- a/aws_log_forwarder/locals.tf
+++ b/aws_log_forwarder/locals.tf
@@ -11,6 +11,16 @@ locals {
   artefact_url_suffix                     = var.artifact_version == "latest" ? "latest/download/brontobytes-aws-ingestion-python.zip" : "download/${var.artifact_version}/brontobytes-aws-ingestion-python.zip"
   artefact_url                            = "https://github.com/brontoio/brontobytes-aws-ingestion-python/releases/${local.artefact_url_suffix}"
   artefact_url_b64sha256                  = "${local.artefact_url}.b64sha256"
+  artefact_bucket_default_name            = "bronto-aws-forwarder-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
+  artefact_bucket                         = var.artifact_bucket.name == null ? {
+      id   = local.artefact_bucket_default_name
+      arn  = "arn:aws:s3:::${local.artefact_bucket_default_name}"
+      name = local.artefact_bucket_default_name
+    } : {
+      id   = var.artifact_bucket.id != null ? var.artifact_bucket.id : var.artifact_bucket.name
+      arn  = var.artifact_bucket.arn != null ? var.artifact_bucket.arn : "arn:aws:s3:::${var.artifact_bucket.name}"
+      name = var.artifact_bucket.name
+    }
   log_groups_with_individual_subscription = [
     for key in keys(var.destination_config) : key
     if lookup(var.destination_config[key], "log_type", "") == "cloudwatch_log" && var.destination_config[key].set_individual_subscription
@@ -24,5 +34,5 @@ locals {
   }
   collector_extension_arn = var.forwarder_logs.collector_extension_arn != null ? var.forwarder_logs.collector_extension_arn : "arn:aws:lambda:${data.aws_region.current.name}:184161586896:layer:opentelemetry-collector-arm64-0_12_0:1"
   otel_config_s3_key = "otel_config/collector.yaml"
-  otel_config_s3_uri = "s3://${var.artifact_bucket.name}.s3.${data.aws_region.current.name}.amazonaws.com/${local.otel_config_s3_key}"
+  otel_config_s3_uri = "s3://${local.artefact_bucket["name"]}.s3.${data.aws_region.current.name}.amazonaws.com/${local.otel_config_s3_key}"
 }

--- a/aws_log_forwarder/output.tf
+++ b/aws_log_forwarder/output.tf
@@ -1,3 +1,8 @@
 output "lambda_arn" {
   value = aws_lambda_function.this.arn
 }
+
+output "artefact_bucket" {
+  description = "The artefact bucket name, ARN and id"
+  value = local.artefact_bucket
+}

--- a/aws_log_forwarder/s3_bucket/bucket.tf
+++ b/aws_log_forwarder/s3_bucket/bucket.tf
@@ -1,0 +1,103 @@
+resource "aws_s3_bucket" "this" {
+    bucket        = var.name
+    force_destroy = false  // Prevent accidental deletion of the bucket
+    tags          = local.tags
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes = [versioning, server_side_encryption_configuration]
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+    bucket = aws_s3_bucket.this.id
+    rule {
+        bucket_key_enabled = true
+        apply_server_side_encryption_by_default {
+            sse_algorithm = "AES256"
+        }
+    }
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+    bucket = aws_s3_bucket.this.id
+    versioning_configuration {
+        status     = var.versioning_configuration.status
+    }
+}
+
+resource "aws_s3_bucket_ownership_controls" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    object_ownership = var.object_ownership
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  count      = var.versioning_configuration.non_current_versions_ttl_days != null || length(keys(var.expiration_rules)) > 0 ? 1 : 0
+  depends_on = [aws_s3_bucket_versioning.this]
+
+  bucket = aws_s3_bucket.this.id
+
+  dynamic rule {
+    for_each = var.versioning_configuration.non_current_versions_ttl_days == null ? [] : ["versions"]
+    content {
+      id       = "expireNonCurrentVersions"
+
+      noncurrent_version_expiration {
+        noncurrent_days = var.versioning_configuration.non_current_versions_ttl_days
+      }
+
+      expiration {
+        expired_object_delete_marker = true
+      }
+
+      status = "Enabled"
+    }
+  }
+
+  dynamic rule {
+    for_each = var.expiration_rules
+    content {
+      id       = rule.key
+
+      dynamic expiration {
+        for_each = rule.value.ttl_days == null ? {} : { expiration = rule.value.ttl_days }
+        content {
+          days = expiration.value
+        }
+      }
+
+      dynamic abort_incomplete_multipart_upload {
+        for_each = rule.value.incomplete_multipart_upload_ttl_days == null ? {} : { incomplete_multipart_upload_ttl_days = rule.value.incomplete_multipart_upload_ttl_days }
+        content {
+          days_after_initiation = abort_incomplete_multipart_upload.value
+        }
+      }
+
+      dynamic filter {
+        for_each = rule.value.filter == null ? {} : { filter = rule.value.filter }
+        content {
+          prefix = filter.value.prefix
+        }
+      }
+
+      status = rule.value.status
+    }
+  }
+}
+# Extra bucket metrics
+resource "aws_s3_bucket_metric" "this" {
+  count  = var.extra_metrics.enabled ? 1 : 0
+  bucket = aws_s3_bucket.this.id
+  name   = var.extra_metrics.filter_id
+}

--- a/aws_log_forwarder/s3_bucket/locals.tf
+++ b/aws_log_forwarder/s3_bucket/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  tags = merge({ name = var.name }, var.tags)
+}

--- a/aws_log_forwarder/s3_bucket/output.tf
+++ b/aws_log_forwarder/s3_bucket/output.tf
@@ -1,0 +1,11 @@
+output "name" {
+  value = aws_s3_bucket.this.bucket
+}
+
+output "id" {
+  value = aws_s3_bucket.this.id
+}
+
+output "arn" {
+  value = aws_s3_bucket.this.arn
+}

--- a/aws_log_forwarder/s3_bucket/policy.tf
+++ b/aws_log_forwarder/s3_bucket/policy.tf
@@ -1,0 +1,5 @@
+resource "aws_s3_bucket_policy" "this" {
+  count  = var.bucket_policy_json == null ? 0 : 1
+  bucket = var.name
+  policy = var.bucket_policy_json
+}

--- a/aws_log_forwarder/s3_bucket/variables.tf
+++ b/aws_log_forwarder/s3_bucket/variables.tf
@@ -1,0 +1,49 @@
+variable "name" {
+  description = "The bucket name"
+}
+
+variable "tags" {
+  description = "Bucket tags. The name tag is inferred from the name variable if not overwritten here."
+  default     = {}
+}
+
+variable "versioning_configuration" {
+  description = "Bucket versioning configuration"
+  type        = object({
+    status: string
+    non_current_versions_ttl_days: number
+  })
+  default     = { status = "Disabled", non_current_versions_ttl_days = null }
+}
+
+variable "object_ownership" {
+  description = "Ownership type to apply to objects"
+  default     = "BucketOwnerEnforced"
+}
+
+variable "expiration_rules" {
+  description = "Lifecycle expiration rules configuration"
+  type        = map(object({
+    status: string
+    ttl_days: optional(number)
+    filter: optional(object({
+      prefix: string
+    }))
+    incomplete_multipart_upload_ttl_days: optional(number)
+  }))
+  default = {}
+}
+
+variable "bucket_policy_json" {
+  description = "JSON representation of the bucket policy"
+  default     = null
+}
+
+variable "extra_metrics" {
+  description = "Whether to enable extra metrics on the bucket, e.g. Request metrics"
+  type        = object({
+    enabled: bool
+    filter_id: string
+  })
+  default     = { enabled = false, filter_id = null }
+}

--- a/aws_log_forwarder/variables.tf
+++ b/aws_log_forwarder/variables.tf
@@ -59,11 +59,12 @@ variable "uncompressed_max_batch_size" {
 }
 
 variable "artifact_bucket" {
-  description = "Config object representing the artifact bucket (a.k.a. codedeploy bucket)"
+  description = "Config object representing the artifact bucket (a.k.a. codedeploy bucket). When create = false and name is null, default name is bronto-aws-forwarder-<ACCOUNT_ID>-<REGION>"
   type        = object({
-    arn: string
-    id: string
-    name: string
+    create: optional(bool, false)
+    arn: optional(string)
+    id: optional(string)
+    name: optional(string)
   })
 }
 


### PR DESCRIPTION
This change makes it possible to opt-into creating a dedicated S3 bucket for the Bronto forwarder. For now, this bucket contains the source code of the Lambda forwarder.