### PR TITLE
Separate S3 and Cloudwatch configuration and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ BrontoBytes.
 ### Forwarding logs delivered to AWS S3
 
 This Terraform module sets up the necessary infrastructure to forward to Bronto, logs delivered to S3 buckets. It relies 
-on AWS S3 Notifications so that an AWS Lambda function gets triggered when a new object is uploaded to an S3 bucket 
+on AWS S3 Notifications or AWS EventBridge so that an AWS Lambda function gets triggered when a new object is uploaded to an S3 bucket 
 (called the Logging Bucket).
 The Lambda function gets notification of the new objects being added to the Logging Bucket, then downloads the object so 
 as to parse its content and send it to Bronto for ingestion.
@@ -25,7 +25,8 @@ as to parse its content and send it to Bronto for ingestion.
 ### Forwarding logs delivered to AWS Cloudwatch
 
 This follows the same principle as for forwarding logs from S3, except that a Cloudwatch Subscriptions are used in order 
-to trigger the forwarding lambda function, rather than S3 notifications. 
+to trigger the forwarding lambda function, rather than S3 notifications. It is recommended to use an account level 
+subscription filter rather than individual subscriptions per log group.
 
 
 ## Usage
@@ -35,16 +36,14 @@ are forwarded to Bronto.
 ```hcl
 module "bronto_aws_log_forwarding" {
   source = "git::https://github.com/brontoio/brontobytes-aws-ingestion-terraform.git//aws_log_forwarder"
-  with_s3_notification = false
-  logging_bucket   = {name="<LOGGING_BUCKET_NAME>", prefix="<LOGGING_BUCKET_PREFIX>"}
+  # Forwarder Lambda
   name             = "bronto_aws_log_forwarder"
   tags             = { Name = "bronto_aws_log_forwarding" }
   timeout_sec      = 30
   storage_size_mb  = 1000
   bronto_api_key   = data.aws_kms_secrets.secrets.plaintext["bronto_api_key"]
-  artifact_bucket  = {name="LAMBDA_ARTIFACT_BUCKET_NAME", id="LAMBDA_ARTIFACT_BUCKET_NAME", arn="arn:aws:s3:::LAMBDA_ARTIFACT_BUCKET_NAME"}
-  artifact_version = "latest"
   uncompressed_max_batch_size = 5000000  # 5Mb
+  attributes = { region = "us-east-1", account_id = "12345678"}
   destination_config   = {
     "/aws/lambda/my-function-name" = {
       dataset    = "<BRONTO DESTINATION LOG_NAME>"
@@ -62,6 +61,12 @@ module "bronto_aws_log_forwarding" {
       log_type   = "cf_standard_access_log"
     }
   },
+  artifact_bucket  = {name="LAMBDA_ARTIFACT_BUCKET_NAME", id="LAMBDA_ARTIFACT_BUCKET_NAME", arn="arn:aws:s3:::LAMBDA_ARTIFACT_BUCKET_NAME"}
+  artifact_version = "latest"
+  # Forwarding data from S3
+  with_s3_notification = false
+  logging_bucket   = {name="<LOGGING_BUCKET_NAME>", prefix="<LOGGING_BUCKET_PREFIX>"}
+  # Forwarding data from Cloudwatch
   cloudwatch_default_collection = "Cloudwatch"
   account_level_cloudwatch_subscription = {
     enable = true
@@ -70,13 +75,86 @@ module "bronto_aws_log_forwarding" {
 }
 ```
 
+Here is another example where only Cloudwatch logs are forwarded to Bronto:
+```hcl
+module "bronto_aws_log_forwarding" {
+  source = "git::https://github.com/brontoio/brontobytes-aws-ingestion-terraform.git//aws_log_forwarder"
+  # Forwarder Lambda
+  name             = "bronto_aws_log_forwarder"
+  tags             = { Name = "bronto_aws_log_forwarding" }
+  timeout_sec      = 30
+  storage_size_mb  = 1000
+  bronto_api_key   = data.aws_kms_secrets.secrets.plaintext["bronto_api_key"]
+  uncompressed_max_batch_size = 5000000  # 5Mb
+  destination_config   = {
+    "/aws/lambda/my-function-name" = {
+      dataset    = "<BRONTO DESTINATION LOG_NAME>"
+      collection = "<BRONTO DESTINATION COLLECTION>"
+      log_type   = "cloudwatch_log"
+    }
+  },
+  artifact_bucket  = {name="LAMBDA_ARTIFACT_BUCKET_NAME", id="LAMBDA_ARTIFACT_BUCKET_NAME", arn="arn:aws:s3:::LAMBDA_ARTIFACT_BUCKET_NAME"}
+  artifact_version = "latest"
+  # Forwarding data from Cloudwatch
+  cloudwatch_default_collection = "Cloudwatch"
+  account_level_cloudwatch_subscription = {
+    enable = true
+    excluded_log_groups = ["log_group1", "log_group2"]
+  }
+}
+```
+
+And here is an example where only S3 logs are forwarded to Bronto:
+```hcl
+module "bronto_aws_log_forwarding" {
+  source = "git::https://github.com/brontoio/brontobytes-aws-ingestion-terraform.git//aws_log_forwarder"
+  # Forwarder Lambda
+  name             = "bronto_aws_log_forwarder"
+  tags             = { Name = "bronto_aws_log_forwarding" }
+  timeout_sec      = 30
+  storage_size_mb  = 1000
+  bronto_api_key   = data.aws_kms_secrets.secrets.plaintext["bronto_api_key"]
+  uncompressed_max_batch_size = 5000000  # 5Mb
+  destination_config   = {
+    "<BUCKET_WHOSE_ACCESS_LOGS_ARE_COLLECTED>" = {
+      dataset    = "<BRONTO DESTINATION LOG_NAME>"
+      collection = "<BRONTO DESTINATION COLLECTION>"
+      log_type   = "s3_access_log"
+    }
+    "<CLOUDFRONT_DISTRIBUBTION_ID>" = {
+      dataset    = "<BRONTO DESTINATION LOG_NAME>"
+      collection = "<BRONTO DESTINATION COLLECTION>"
+      log_type   = "cf_standard_access_log"
+    }
+  }
+  artifact_bucket  = {name="LAMBDA_ARTIFACT_BUCKET_NAME", id="LAMBDA_ARTIFACT_BUCKET_NAME", arn="arn:aws:s3:::LAMBDA_ARTIFACT_BUCKET_NAME"}
+  artifact_version = "latest"
+  # Forwarding data from S3
+  with_s3_notification = false
+  logging_bucket = {name="<LOGGING_BUCKET_NAME>", prefix="<LOGGING_BUCKET_PREFIX>"}
+}
+```
+
 Below is a list of fields that can be used to configure this module.
 
-For the forwarding Lambda function:
+### Forwarder Lambda
+
+Lambda related configuration:
 - `name`: the name to use for the lambda function
 - `tags`: key-value pairs defining AWS tags to be applied to the resources created by the module
 - `timeout_sec`: the lambda function timeout value
 - `storage_size_mb`: the lambda function storage size
+
+Bronto related configuration, these are provided to the Lambda function as environment variables:
+- `bronto_api_key`: the Bronto API key
+- `uncompressed_max_batch_size`: the max size of the batches of data to be forwarded to Bronto
+- `destination_config`: map of configurations indicating the type of data to be forwarded as well as the destination
+  in Bronto where to send the data to. When forwarding data from Cloudwatch log groups, it is recommended to use account 
+level subscription filters and therefore not to add entries for log groups to this map. For data forwarded from S3, only 
+data matching entries in this map is forwarded and adding entries is therefore required in that case.
+- `attributes`: map of keys and values added to log data as log attributes, e.g. `{ region = "us-east-1", account_id = "12345678"}` 
+
+Lambda artefact:
 
 The lambda code artifact is automatically downloaded from Bronto's Github repository and uploaded to S3. The following 
 attributes specify the bucket where to upload the artifact to so that is can be used to define the forwarding lambda. 
@@ -85,26 +163,28 @@ attributes specify the bucket where to upload the artifact to so that is can be 
 (currently `bronto-aws-forwarder-<ACCOUNT_ID>-<REGION>`).
 - `artifact_version`: the version of the lambda artifact to be used, e.g. `latest`
 
-For data delivered to S3:
+### Forwarding from S3:
 - `with_s3_notification`: boolean value indicating whether S3 notification should be created with this module (see note below)
+- `with_eventbridge_rule`: boolean value indicating whether an EventBridge rule should be created with this module
+- `enable_eventbridge_notification`: boolean value indicating whether EventBridge should be used in order to send notifications
 - `logging_bucket`: an object defining the name of the bucket and prefix where the data to be forwarded is located 
 
-Bronto related configuration:
-- `bronto_api_key`: the Bronto API key
-- `uncompressed_max_batch_size`: the max size of the batches of data to be forwarded to Bronto
-- `destination_config`: list of configurations indicating the type of data to be forwarded as well as the destination 
-in Bronto where to send the data to. For Cloudwatch log groups, this module provides the ability to 
-create an account level subscription filter via the `account_level_cloudwatch_subscription` property. When enabled, 
-data of all log groups will be received and forwarded by the Bronto Lambda forwarder. The destination collection can be 
-set with the `cloudwatch_default_collection` property, while the destination dataset is represented by the log group 
-name. More details can be found in the [forwarding Lambda function repository](https://github.com/brontoio/brontobytes-aws-ingestion-python). 
-
-
-
-**Note:** The `with_s3_notification` variable makes it possible to control whether S3 notifications get set up as part of 
+**Note:** The `with_s3_notification` variable makes it possible to control whether S3 notifications get set up as part of
 instantiating this module. In one hand, it is necessary to set an S3 notification on the bucket containing the log data in
-order to trigger the lambda function created by this module. On the other hand, the S3 API does not support for S3 
-notifications to be added but rather for all of them to be set together. Therefore, setting S3 notification with this 
-module is only relevant if no other notifications are set on the bucket. In order to handle the case of other 
-notifications being present on the bucket, best is to set `with_s3_notification` to false and create the needed 
-notifications the same was as the other ones are.
+order to trigger the lambda function created by this module. On the other hand, the S3 API does not support for S3
+notifications to be added but rather for all of them to be set together. Therefore, setting S3 notification with this
+module is only relevant if no other notifications are set on the bucket. In order to handle the case of other
+notifications being present on the bucket, best is to set `with_s3_notification` to false and create the needed
+notifications with already existing Terraform definition for the S3 notification resource.
+
+### Forwarding from Cloudwatch:
+
+The following variables can be used to configure the forwarder when forwarding data from Cloudwatch.
+ 
+- `account_level_cloudwatch_subscription`: configuration to create an account level subscription filter and exclude specific Cloudwatch log groups 
+(the Bronto forwarder log group is automatically excluded and does not need to be specified), e.g. `account_level_cloudwatch_subscription = { create = true }`. 
+When enabled, data of all log groups will be received and forwarded by the Bronto Lambda forwarder. This is the recommended approach.
+Note: AWS currently only support a single account level subscription. So this approach is only suitable if no other account level subscription are already in place. 
+- `cloudwatch_default_collection`: the Bronto Collection where Cloudwatch data is sent to. The destination dataset is represented by the log group 
+name. More details can be found in the [forwarding Lambda function repository](https://github.com/brontoio/brontobytes-aws-ingestion-python). Destination collections 
+and datasets can be overwritten via the `destination_config` parameter described above if required. 

--- a/aws_log_forwarder/artefact.tf
+++ b/aws_log_forwarder/artefact.tf
@@ -1,0 +1,21 @@
+data "http" "package" {
+  url = local.artefact_url
+}
+
+data "http" "package_b64sha256" {
+  url = local.artefact_url_b64sha256
+}
+
+module "artefact_bucket" {
+  count  = var.artifact_bucket.create ? 1 : 0
+  source = "./s3_bucket"
+  name   = local.artefact_bucket["name"]
+  tags   = var.tags
+}
+
+resource "aws_s3_object" "log_forwarder" {
+  bucket         = local.artefact_bucket["name"]
+  key            = "${var.name}/${local.filename}"
+  content_base64 = data.http.package.response_body_base64
+  depends_on     = [module.artefact_bucket]
+}

--- a/aws_log_forwarder/cloudwatch_forwarding.tf
+++ b/aws_log_forwarder/cloudwatch_forwarding.tf
@@ -7,6 +7,7 @@ resource "aws_cloudwatch_log_subscription_filter" "this" {
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch" {
+  count         = local.enable_cloudwatch_forwarding ? 1 : 0
   statement_id  = "${replace(title(replace(var.name, "_", " ")), " ", "")}AllowExecutionFromCloudwatch"
   action        = "lambda:InvokeFunction"
   function_name = var.name
@@ -14,7 +15,7 @@ resource "aws_lambda_permission" "allow_cloudwatch" {
 }
 
 resource "aws_cloudwatch_log_account_policy" "subscription_filter" {
-  count       = var.account_level_cloudwatch_subscription.enable ? 1 : 0
+  count       = local.enable_account_level_subscription_filter ? 1 : 0
   policy_name = "subscription-filter"
   policy_type = "SUBSCRIPTION_FILTER_POLICY"
   policy_document = jsonencode(

--- a/aws_log_forwarder/iam.tf
+++ b/aws_log_forwarder/iam.tf
@@ -1,3 +1,4 @@
+# Lambda
 data "aws_iam_policy_document" "assume_role" {
   statement {
     effect = "Allow"
@@ -15,30 +16,6 @@ resource "aws_iam_role" "this" {
   count              = var.role_name == null ? 1 : 0
   name               = local.role_name
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
-}
-
-data "aws_iam_policy_document" "s3_access" {
-
-  statement {
-    effect = "Allow"
-    resources = [
-      "${local.logging_bucket_prefix_arn}*",
-      "${local.artefact_bucket["arn"]}/${var.name}/*",
-      "${local.artefact_bucket["arn"]}/${local.otel_config_s3_key}"
-    ]
-    actions   = ["s3:Get*", "s3:List*"]
-  }
-}
-
-resource "aws_iam_policy" "s3_access" {
-  policy = data.aws_iam_policy_document.s3_access.json
-}
-
-resource "aws_iam_policy_attachment" "s3_access" {
-  name       = "S3AccessLoggingBucketRO"
-  policy_arn = aws_iam_policy.s3_access.arn
-  roles      = [local.role_name]
-  depends_on = [aws_iam_role.this]
 }
 
 resource "aws_iam_role_policy_attachment" "basic" {

--- a/aws_log_forwarder/locals.tf
+++ b/aws_log_forwarder/locals.tf
@@ -3,10 +3,23 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
+  # Lambda
   role_name                               = var.role_name == null ? "${var.name}-role" : var.role_name
   role_arn                                = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.role_name}"
-  logging_bucket_arn                      = "arn:aws:s3:::${var.logging_bucket.name}"
-  logging_bucket_prefix_arn               = "${local.logging_bucket_arn}/${var.logging_bucket.prefix}"
+  fct_destination_properties              = {
+    for key, value in var.destination_config : key =>
+    {for prop in keys(value) : prop => value[prop] if prop != "set_individual_subscription"}
+  }
+  collector_extension_arn = var.forwarder_logs.collector_extension_arn != null ? var.forwarder_logs.collector_extension_arn : "arn:aws:lambda:${data.aws_region.current.name}:184161586896:layer:opentelemetry-collector-arm64-0_12_0:1"
+  otel_config_s3_key = "otel_config/collector.yaml"
+  otel_config_s3_uri = "s3://${local.artefact_bucket["name"]}.s3.${data.aws_region.current.name}.amazonaws.com/${local.otel_config_s3_key}"
+
+  # s3 forwarding
+  enable_s3_forwarding                    = var.logging_bucket != null
+  logging_bucket_arn                      = local.enable_s3_forwarding ? "arn:aws:s3:::${var.logging_bucket.name}" : null
+  logging_bucket_prefix_arn               = local.enable_s3_forwarding ? "${local.logging_bucket_arn}/${var.logging_bucket.prefix}" : null
+
+  # Artefact
   filename                                = "lambda_${var.name}.zip"
   artefact_url_suffix                     = var.artifact_version == "latest" ? "latest/download/brontobytes-aws-ingestion-python.zip" : "download/${var.artifact_version}/brontobytes-aws-ingestion-python.zip"
   artefact_url                            = "https://github.com/brontoio/brontobytes-aws-ingestion-python/releases/${local.artefact_url_suffix}"
@@ -21,18 +34,13 @@ locals {
       arn  = var.artifact_bucket.arn != null ? var.artifact_bucket.arn : "arn:aws:s3:::${var.artifact_bucket.name}"
       name = var.artifact_bucket.name
     }
+
+  # Cloudwatch forwarding
   log_groups_with_individual_subscription = [
     for key in keys(var.destination_config) : key
     if lookup(var.destination_config[key], "log_type", "") == "cloudwatch_log" && var.destination_config[key].set_individual_subscription
   ]
-  excluded_log_groups = concat(var.account_level_cloudwatch_subscription.excluded_log_groups, [
-    aws_cloudwatch_log_group.this.name
-  ], local.log_groups_with_individual_subscription)
-  fct_destination_properties              = {
-    for key, value in var.destination_config : key =>
-    {for prop in keys(value) : prop => value[prop] if prop != "set_individual_subscription"}
-  }
-  collector_extension_arn = var.forwarder_logs.collector_extension_arn != null ? var.forwarder_logs.collector_extension_arn : "arn:aws:lambda:${data.aws_region.current.name}:184161586896:layer:opentelemetry-collector-arm64-0_12_0:1"
-  otel_config_s3_key = "otel_config/collector.yaml"
-  otel_config_s3_uri = "s3://${local.artefact_bucket["name"]}.s3.${data.aws_region.current.name}.amazonaws.com/${local.otel_config_s3_key}"
+  excluded_log_groups = var.account_level_cloudwatch_subscription == null ? [] : concat(var.account_level_cloudwatch_subscription.excluded_log_groups, [aws_cloudwatch_log_group.this.name], local.log_groups_with_individual_subscription)
+  enable_account_level_subscription_filter = var.account_level_cloudwatch_subscription != null ? var.account_level_cloudwatch_subscription.enable : false
+  enable_cloudwatch_forwarding = local.enable_account_level_subscription_filter || length(local.log_groups_with_individual_subscription) > 0
 }

--- a/aws_log_forwarder/s3_bucket/bucket.tf
+++ b/aws_log_forwarder/s3_bucket/bucket.tf
@@ -95,6 +95,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     }
   }
 }
+
 # Extra bucket metrics
 resource "aws_s3_bucket_metric" "this" {
   count  = var.extra_metrics.enabled ? 1 : 0

--- a/aws_log_forwarder/s3_forwarding.tf
+++ b/aws_log_forwarder/s3_forwarding.tf
@@ -1,0 +1,63 @@
+# IAM
+data "aws_iam_policy_document" "s3_access" {
+  count = local.enable_s3_forwarding ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    resources = [
+      "${local.logging_bucket_prefix_arn}*",
+      "${local.artefact_bucket["arn"]}/${var.name}/*",
+      "${local.artefact_bucket["arn"]}/${local.otel_config_s3_key}"
+    ]
+    actions   = ["s3:Get*", "s3:List*"]
+  }
+}
+
+resource "aws_iam_policy" "s3_access" {
+  count  = local.enable_s3_forwarding ? 1 : 0
+  policy = data.aws_iam_policy_document.s3_access[0].json
+}
+
+resource "aws_iam_policy_attachment" "s3_access" {
+  count      = local.enable_s3_forwarding ? 1 : 0
+  name       = "S3AccessLoggingBucketRO"
+  policy_arn = aws_iam_policy.s3_access[0].arn
+  roles      = [local.role_name]
+  depends_on = [aws_iam_role.this]
+}
+
+# Lambda permissions
+resource "aws_lambda_permission" "allow_bucket" {
+  count         = local.enable_s3_forwarding ? 1 : 0
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.this.arn
+  principal     = "s3.amazonaws.com"
+  source_arn    = local.logging_bucket_arn
+}
+
+# S3 Notifications and EventBridge
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  count  = local.enable_s3_forwarding && (var.with_s3_notification || var.enable_eventbridge_notification) ? 1 : 0
+  bucket = var.logging_bucket.name
+  eventbridge = var.enable_eventbridge_notification
+
+
+  dynamic lambda_function {
+    for_each = var.with_s3_notification ? { (var.name) = "1" } : {}
+    content {
+      lambda_function_arn = aws_lambda_function.this.arn
+      events              = ["s3:ObjectCreated:*"]
+      filter_prefix       = var.logging_bucket.prefix
+    }
+  }
+}
+
+module "event_bridge" {
+  count  = local.enable_s3_forwarding && var.with_eventbridge_rule ? 1 : 0
+  source = "./notifications/"
+  lambda_function_arn = aws_lambda_function.this.arn
+  logging_bucket      = var.logging_bucket
+  name                = var.name
+  tags                = { Name = "bronto-log-forwarder" }
+}

--- a/aws_log_forwarder/variables.tf
+++ b/aws_log_forwarder/variables.tf
@@ -8,6 +8,7 @@ variable "logging_bucket" {
     name: string
     prefix: optional(string, "")
   })
+  default = null
 }
 
 variable "destination_config" {
@@ -66,6 +67,10 @@ variable "artifact_bucket" {
     id: optional(string)
     name: optional(string)
   })
+  validation {
+    condition = var.artifact_bucket.create || var.artifact_bucket.name != null
+    error_message = "The artefact bucket name must be specified when using an existing artefact bucket"
+  }
 }
 
 variable "artifact_version" {
@@ -102,6 +107,7 @@ variable "account_level_cloudwatch_subscription" {
     enable: optional(bool, true)
     excluded_log_groups: optional(list(string), [])
   })
+  default = null
 }
 
 variable "cloudwatch_default_collection" {
@@ -124,4 +130,10 @@ variable "forwarder_logs" {
   default = {
     forward_enable = false
   }
+}
+
+variable "attributes" {
+  description = "Attributes that apply to all data forwarded, e.g. region=us-east-1"
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
This change is to properly support the case of users that would only forward Cloudwatch or S3 logs.