### PR TITLE
BRONTO-1948 decouple logging bucket and artefact bucket permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Lambda related configuration:
 
 Bronto related configuration, these are provided to the Lambda function as environment variables:
 - `bronto_api_key`: the Bronto API key
+- `bronto_ingestion_endpoint`: the Bronto ingestion endpoint, e.g. https://ingestion.eu.bronto.io/. This endpoint must
+point to the Bronto system where the API key was created.  
 - `uncompressed_max_batch_size`: the max size of the batches of data to be forwarded to Bronto
 - `destination_config`: map of configurations indicating the type of data to be forwarded as well as the destination
   in Bronto where to send the data to. When forwarding data from Cloudwatch log groups, it is recommended to use account 

--- a/aws_log_forwarder/iam.tf
+++ b/aws_log_forwarder/iam.tf
@@ -12,6 +12,30 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
+data "aws_iam_policy_document" "s3_artefact_access" {
+
+  statement {
+    effect = "Allow"
+    resources = [
+      "${local.artefact_bucket["arn"]}/${var.name}/*",
+      "${local.artefact_bucket["arn"]}/${local.otel_config_s3_key}",
+      "${local.artefact_bucket["arn"]}/${local.destination_config_s3_key}",
+      "${local.artefact_bucket["arn"]}/${local.paths_regex_config_s3_key}"
+    ]
+    actions   = ["s3:Get*", "s3:List*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = [local.artefact_bucket.arn]
+    actions   = ["s3:ListBucket"]
+  }
+}
+
+resource "aws_iam_policy" "s3_artefact_access" {
+  policy = data.aws_iam_policy_document.s3_artefact_access.json
+}
+
 resource "aws_iam_role" "this" {
   count              = local.create_role ? 1 : 0
   name               = local.role_name
@@ -20,6 +44,12 @@ resource "aws_iam_role" "this" {
 
 resource "aws_iam_role_policy_attachment" "basic" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  role       = local.role_name
+  depends_on = [aws_iam_role.this]
+}
+
+resource "aws_iam_role_policy_attachment" "s3_artefact_access" {
+  policy_arn = aws_iam_policy.s3_artefact_access.arn
   role       = local.role_name
   depends_on = [aws_iam_role.this]
 }

--- a/aws_log_forwarder/s3_forwarding.tf
+++ b/aws_log_forwarder/s3_forwarding.tf
@@ -5,11 +5,7 @@ data "aws_iam_policy_document" "s3_access" {
   statement {
     effect = "Allow"
     resources = [
-      "${local.logging_bucket_prefix_arn}*",
-      "${local.artefact_bucket["arn"]}/${var.name}/*",
-      "${local.artefact_bucket["arn"]}/${local.otel_config_s3_key}",
-      "${local.artefact_bucket["arn"]}/${local.destination_config_s3_key}",
-      "${local.artefact_bucket["arn"]}/${local.paths_regex_config_s3_key}"
+      "${local.logging_bucket_prefix_arn}*"
     ]
     actions   = ["s3:Get*", "s3:List*"]
   }

--- a/aws_log_forwarder/variables.tf
+++ b/aws_log_forwarder/variables.tf
@@ -55,7 +55,7 @@ variable "bronto_api_key" {
 
 variable "bronto_ingestion_endpoint" {
   description = "Bronto ingestion endpoint"
-  default     = "https://ingestion.brontobytes.io/"
+  default     = "https://ingestion.eu.bronto.io/"
 }
 
 variable "bronto_otel_logs_endpoint" {


### PR DESCRIPTION
There is currently a single policy for all s3 access and it is conditioned to whether forwarding log data from S3 is enabled. This is problematic for users who wish to only send log data from Cloudwatch as S3 access is still required for artefacts such as the forwarder code and configuration.

This change splits S3 access policy so that access to the artefact bucket is granted, independently of whether S3 forwarding being enabled.
This change also changes the default endpoint to its newer version, which includes the region code (`eu`).