### PR TITLE
Add support for custom subscription filter patterns

### DIFF
--- a/aws_log_forwarder/cloudwatch_forwarding.tf
+++ b/aws_log_forwarder/cloudwatch_forwarding.tf
@@ -2,7 +2,7 @@ resource "aws_cloudwatch_log_subscription_filter" "this" {
   for_each        = { for key in local.log_groups_with_individual_subscription: key => var.destination_config[key] }
   name            = var.name
   log_group_name  = each.key
-  filter_pattern  = ""
+  filter_pattern  = each.value["subscription_filter_pattern"] == null ? var.default_subscription_filter_pattern : each.value["subscription_filter_pattern"]
   destination_arn = aws_lambda_function.this.arn
 }
 
@@ -21,7 +21,7 @@ resource "aws_cloudwatch_log_account_policy" "subscription_filter" {
   policy_document = jsonencode(
     {
       DestinationArn = aws_lambda_function.this.arn
-      FilterPattern  = ""
+      FilterPattern  = var.default_subscription_filter_pattern
     }
   )
   selection_criteria = "LogGroupName NOT IN [${join(",", formatlist("\"%s\"", local.excluded_log_groups))}]"

--- a/aws_log_forwarder/locals.tf
+++ b/aws_log_forwarder/locals.tf
@@ -10,7 +10,7 @@ locals {
   role_arn                                = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.role_name}"
   fct_destination_properties              = {
     for key, value in var.destination_config : key =>
-    {for prop in keys(value) : prop => value[prop] if prop != "set_individual_subscription"}
+    {for prop in ["logname", "logset", "log_type"]  : prop => value[prop]}
   }
   collector_extension_arn = var.forwarder_logs.collector_extension_arn != null ? var.forwarder_logs.collector_extension_arn : "arn:aws:lambda:${local.region_name}:184161586896:layer:opentelemetry-collector-arm64-0_12_0:1"
   otel_config_s3_key        = "config/collector.yaml"
@@ -42,7 +42,7 @@ locals {
   # Cloudwatch forwarding
   log_groups_with_individual_subscription = [
     for key in keys(var.destination_config) : key
-    if lookup(var.destination_config[key], "log_type", "") == "cloudwatch_log" && var.destination_config[key].set_individual_subscription
+    if var.destination_config[key].log_type == "cloudwatch_log" && var.destination_config[key].set_individual_subscription == true
   ]
   excluded_log_groups = var.account_level_cloudwatch_subscription == null ? [] : concat(var.account_level_cloudwatch_subscription.excluded_log_groups, [aws_cloudwatch_log_group.this.name], local.log_groups_with_individual_subscription)
   enable_account_level_subscription_filter = var.account_level_cloudwatch_subscription != null ? var.account_level_cloudwatch_subscription.enable : false


### PR DESCRIPTION
A default subscription filter pattern can be set, which applies to all subscription filters, i.e. both on account level and log group level subscription filters. It is named `default_subscription_filter_pattern`.

The default subscription filter pattern can be overwritten at the log group level with the `subscription_filter_pattern` attribute, set in the `destination_config` section of the forwarder configuration.

This change also extends README.md with details on the `destination_config` section of the configuration as well as the validation of the attributes defined in the `destination_config` section of the configuration.