### PR TITLE
Add support for dataset level tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ data matching entries in this map is forwarded and adding entries is therefore r
   - set_individual_subscription: if set to true, then a log group subscription filter is set. Otherwise, the forwarder 
   relies on an account level subscription filter. 
   - subscription_filter_pattern: the subscription filter pattern to apply to the log group level subscription filter. 
-  This overwrites the default level subscription filter pattern. 
+  This overwrites the default level subscription filter pattern.
+  - tags: a map whose values are strings, representing tags to be associated to the Bronto dataset, e.g. `{"key1": "value1", "key2": "value2"}`.
 - `paths_regex`: list of regex patterns to match against S3 key, e.g.
 - `default_subscription_filter_pattern`: the default filter pattern to apply to cloudwatch log group subscriptions. The 
 `subscription_filter_pattern` attribute of entries in `destination_config` takes precedence over 

--- a/aws_log_forwarder/locals.tf
+++ b/aws_log_forwarder/locals.tf
@@ -10,7 +10,7 @@ locals {
   role_arn                                = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.role_name}"
   fct_destination_properties              = {
     for key, value in var.destination_config : key =>
-    {for prop in ["logname", "logset", "log_type"]  : prop => value[prop]}
+    {for prop in ["logname", "logset", "log_type", "tags"]  : prop => value[prop]}
   }
   collector_extension_arn = var.forwarder_logs.collector_extension_arn != null ? var.forwarder_logs.collector_extension_arn : "arn:aws:lambda:${local.region_name}:184161586896:layer:opentelemetry-collector-arm64-0_12_0:1"
   otel_config_s3_key        = "config/collector.yaml"

--- a/aws_log_forwarder/variables.tf
+++ b/aws_log_forwarder/variables.tf
@@ -17,6 +17,7 @@ variable "destination_config" {
     logname: string
     logset: string
     log_type: string
+    tags: optional(map(string), {})
     set_individual_subscription: optional(bool)
     subscription_filter_pattern: optional(string)
   }))


### PR DESCRIPTION
Currently only default tag is aws_log_type, which indicates the type of logs that the dataset contains, e.g. cloudwatch_log, s3_access_log, etc