### PR TITLE
Add support to overwrite the artifact URL

### DIFF
--- a/aws_log_forwarder/locals.tf
+++ b/aws_log_forwarder/locals.tf
@@ -26,7 +26,7 @@ locals {
   # Artefact
   filename                                = "lambda_${var.name}.zip"
   artefact_url_suffix                     = var.artifact_version == "latest" ? "latest/download/brontobytes-aws-ingestion-python.zip" : "download/${var.artifact_version}/brontobytes-aws-ingestion-python.zip"
-  artefact_url                            = "https://github.com/brontoio/brontobytes-aws-ingestion-python/releases/${local.artefact_url_suffix}"
+  artefact_url                            = var.artifact_url == null ? "https://github.com/brontoio/brontobytes-aws-ingestion-python/releases/${local.artefact_url_suffix}" : var.artifact_url
   artefact_url_b64sha256                  = "${local.artefact_url}.b64sha256"
   artefact_bucket_default_name            = "bronto-aws-forwarder-${data.aws_caller_identity.current.account_id}-${local.region_name}"
   artefact_bucket                         = var.artifact_bucket.name == null ? {

--- a/aws_log_forwarder/variables.tf
+++ b/aws_log_forwarder/variables.tf
@@ -97,6 +97,11 @@ variable "artifact_version" {
   default     = "latest"
 }
 
+variable "artifact_url" {
+  description = "The URL to the log forwarder Lambda artefact, e.g. https://github.com/brontoio/brontobytes-aws-ingestion-python/releases/latest"
+  default     = null
+}
+
 variable "role_name" {
   description = "The name of an existing role to be used. No role is created if this property is set."
   default     = null


### PR DESCRIPTION
This is to allow for custom lambda artifact to be used as forwarder.